### PR TITLE
fix(table): fix stack list silent crash on null resource_control

### DIFF
--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -213,6 +213,7 @@ fn process_table_value(value: &serde_json::Value) -> Cell {
                 cell!(value.to_string())
             }
         }
+        serde_json::Value::Null => cell!(""),
         serde_json::Value::String(s) => cell!(s),
         _ => cell!(value.to_string()),
     }

--- a/src/commands/stacks/models/list.rs
+++ b/src/commands/stacks/models/list.rs
@@ -20,7 +20,7 @@ pub(crate) struct StackList {
     #[serde(deserialize_with = "from_ts_option")]
     pub(crate) update_date: Option<DateTime<Utc>>,
     pub(crate) updated_by: Option<String>,
-    pub(crate) resource_control: ResourceControl,
+    pub(crate) resource_control: Option<ResourceControl>,
 }
 
 #[cfg(test)]
@@ -52,6 +52,27 @@ mod tests {
         let stack: StackList = serde_json::from_str(json).unwrap();
         assert_eq!(stack.id, 1);
         assert_eq!(stack.name, "my-stack");
+        assert!(stack.resource_control.is_some());
+    }
+
+    #[test]
+    fn stack_list_deserialize_null_resource_control() {
+        let json = r#"{
+            "Id": 2,
+            "Name": "no-rc-stack",
+            "Type": 1,
+            "Status": 2,
+            "SwarmId": "",
+            "EndpointId": 1,
+            "CreationDate": 1700000000,
+            "CreatedBy": "admin",
+            "UpdateDate": null,
+            "UpdatedBy": null,
+            "ResourceControl": null
+        }"#;
+        let stack: StackList = serde_json::from_str(json).unwrap();
+        assert_eq!(stack.id, 2);
+        assert!(stack.resource_control.is_none());
     }
 
     #[test]
@@ -78,5 +99,6 @@ mod tests {
         }"#;
         let stack: StackList = serde_json::from_str(json).unwrap();
         assert_eq!(stack.id, 2);
+        assert!(stack.resource_control.is_some());
     }
 }


### PR DESCRIPTION
`wrpt stack list` silently fails and results in empty output if there exists a stack with null `StackList::resource_control`.

This PR:
* Changes the type from `ResourceControl` to `Option<ResourceControl>` so the command does not fail silently.
* Parses `serde_json::Value::Null` into an empty string to prevent the value showing as `null`.
* Adds an unit test to verify that a stack with `"ResourceControl": null` in the API response correctly deserializes to `StackList` with `resource_control: None` rather than crashing.

<img width="716" height="658" alt="image" src="https://github.com/user-attachments/assets/cf10502c-e62c-420b-b4a1-ca2eda64a806" />

Note that `Stack` in `src/commands/stacks/models/deploy.rs` does not need any changes since the `resource_control` is already `Option<ResourceControl>`

```
󰣇 ~/Projects/wrpt   HEAD(5080bbc)   $ ❮ rg 'resource_control: '                                                                                                                                                             rs    22:10
src/commands/stacks/models/list.rs
23:    pub(crate) resource_control: ResourceControl,

src/commands/stacks/models/deploy.rs
60:    pub(crate) resource_control: Option<ResourceControl>,
```
