### PR TITLE
fix(stacks): fix stack name resolution not filtering by endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +88,16 @@ checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -207,6 +226,15 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "const_format"
@@ -435,6 +463,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +558,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +576,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -835,6 +882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +926,31 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -979,6 +1060,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fecab3723493c7851f292cb060f3ee1c42f19b8d749345d0d7eaf3fd19aa62d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1111,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettytable-rs"
@@ -1041,15 +1154,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1103,7 +1289,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -1190,6 +1376,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1464,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simplelog"
@@ -1492,6 +1690,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.52.0",
@@ -1636,6 +1835,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1961,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +2079,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,6 +2105,7 @@ dependencies = [
  "clap",
  "const_format",
  "log",
+ "mockito",
  "prettytable-rs",
  "reqwest",
  "serde",
@@ -1916,6 +2137,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ chrono = { version = "0.4.39", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"
+mockito = "1"

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -56,21 +56,21 @@ pub(crate) fn create_client(api_key: &str, insecure: bool) -> Result<Client, Cli
 pub(crate) fn get_stack_id_from_name(
     ctx: &CliContext,
     name: &str,
+    endpoint_id: u32,
 ) -> Result<Option<u32>, CliError> {
-    let stacks = fetch_stacks(ctx)?;
-
-    for stack in stacks {
-        if stack.name.eq(name) {
-            return Ok(Some(stack.id));
-        }
-    }
-
-    Ok(None)
+    Ok(fetch_stacks(ctx)?
+        .iter()
+        .find(|s| s.name == name && s.endpoint_id == endpoint_id)
+        .map(|s| s.id))
 }
 
 /// Resolves a stack by name, returning its ID or an error if it doesn't exist.
-pub(crate) fn resolve_stack(ctx: &CliContext, stack_name: &str) -> Result<u32, CliError> {
-    let stack_id = get_stack_id_from_name(ctx, stack_name)?;
+pub(crate) fn resolve_stack(
+    ctx: &CliContext,
+    stack_name: &str,
+    endpoint_id: u32,
+) -> Result<u32, CliError> {
+    let stack_id = get_stack_id_from_name(ctx, stack_name, endpoint_id)?;
     stack_id.ok_or_else(|| {
         error!("Stack \"{}\" does not exist", stack_name);
         CliError::Api(format!("stack \"{}\" does not exist", stack_name))

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -523,6 +523,85 @@ mod tests {
         assert!(client.is_ok());
     }
 
+    // --- get_stack_id_from_name tests ---
+
+    #[test]
+    fn get_stack_id_from_name_filters_by_endpoint_id() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/api/stacks")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"[
+                {
+                    "Id": 1,
+                    "Name": "my-stack",
+                    "Type": 2,
+                    "Status": 1,
+                    "SwarmId": "",
+                    "EndpointId": 5,
+                    "CreationDate": 1700000000,
+                    "CreatedBy": "admin",
+                    "UpdateDate": null,
+                    "UpdatedBy": null,
+                    "ResourceControl": {
+                        "Id": 10,
+                        "ResourceId": "1_my-stack",
+                        "Type": 6,
+                        "UserAccesses": [],
+                        "TeamAccesses": [],
+                        "Public": true
+                    }
+                },
+                {
+                    "Id": 2,
+                    "Name": "my-stack",
+                    "Type": 2,
+                    "Status": 1,
+                    "SwarmId": "",
+                    "EndpointId": 8,
+                    "CreationDate": 1700000000,
+                    "CreatedBy": "admin",
+                    "UpdateDate": null,
+                    "UpdatedBy": null,
+                    "ResourceControl": {
+                        "Id": 11,
+                        "ResourceId": "2_my-stack",
+                        "Type": 6,
+                        "UserAccesses": [],
+                        "TeamAccesses": [],
+                        "Public": false
+                    }
+                }
+            ]"#,
+            )
+            .expect(3)
+            .create();
+
+        let ctx = CliContext {
+            client: create_client("test-token", false).unwrap(),
+            base_url: server.url(),
+        };
+
+        // Same name on endpoint 5 → returns stack id 1
+        assert_eq!(
+            get_stack_id_from_name(&ctx, "my-stack", 5).unwrap(),
+            Some(1)
+        );
+
+        // Same name on endpoint 8 → returns stack id 2 (not 1!)
+        assert_eq!(
+            get_stack_id_from_name(&ctx, "my-stack", 8).unwrap(),
+            Some(2)
+        );
+
+        // No stack on endpoint 99 → returns None
+        assert_eq!(get_stack_id_from_name(&ctx, "my-stack", 99).unwrap(), None);
+
+        mock.assert();
+    }
+
     // --- CliError display ---
 
     #[test]

--- a/src/commands/stacks/handlers/deploy.rs
+++ b/src/commands/stacks/handlers/deploy.rs
@@ -28,7 +28,7 @@ pub(crate) fn handler(command: StackDeployCommand, ctx: &CliContext) -> Result<(
     debug!("env_file = {:?}", env_file);
 
     info!("Getting stack info...");
-    let stack_id = get_stack_id_from_name(ctx, command.stack_name.as_str())?;
+    let stack_id = get_stack_id_from_name(ctx, command.stack_name.as_str(), command.endpoint)?;
 
     let stack: Vec<Stack> = if stack_id.is_none() {
         info!("Stack \"{}\" does not exist", command.stack_name);

--- a/src/commands/stacks/handlers/remove.rs
+++ b/src/commands/stacks/handlers/remove.rs
@@ -8,7 +8,7 @@ pub(crate) fn handler(command: StackRemoveCommand, ctx: &CliContext) -> Result<(
     debug!("command = {:?}", command);
 
     info!("Getting stack info...");
-    let stack_id = resolve_stack(ctx, &command.stack_name)?;
+    let stack_id = resolve_stack(ctx, &command.stack_name, command.endpoint)?;
 
     info!(
         "Stack \"{}\" exists (id = {})",

--- a/src/commands/stacks/handlers/resource_control.rs
+++ b/src/commands/stacks/handlers/resource_control.rs
@@ -14,7 +14,7 @@ pub(crate) fn handler(
     debug!("command = {:?}", command);
 
     info!("Getting stack info...");
-    let stack_id = resolve_stack(ctx, &command.stack_name)?;
+    let stack_id = resolve_stack(ctx, &command.stack_name, command.endpoint)?;
 
     info!(
         "Stack \"{}\" exists (id = {})",

--- a/src/commands/stacks/handlers/start.rs
+++ b/src/commands/stacks/handlers/start.rs
@@ -8,7 +8,7 @@ pub(crate) fn handler(command: StackStartCommand, ctx: &CliContext) -> Result<()
     debug!("command = {:?}", command);
 
     info!("Getting stack info...");
-    let stack_id = resolve_stack(ctx, &command.stack_name)?;
+    let stack_id = resolve_stack(ctx, &command.stack_name, command.endpoint)?;
 
     info!(
         "Stack \"{}\" exists (id = {})",

--- a/src/commands/stacks/handlers/stop.rs
+++ b/src/commands/stacks/handlers/stop.rs
@@ -8,7 +8,7 @@ pub(crate) fn handler(command: StackStopCommand, ctx: &CliContext) -> Result<(),
     debug!("command = {:?}", command);
 
     info!("Getting stack info...");
-    let stack_id = resolve_stack(ctx, &command.stack_name)?;
+    let stack_id = resolve_stack(ctx, &command.stack_name, command.endpoint)?;
 
     info!(
         "Stack \"{}\" exists (id = {})",


### PR DESCRIPTION
get_stack_id_from_name matched stacks by name only, without considering the endpoint. Since the same stack name can exist across multiple endpoints, this could return the wrong stack ID.

This PR adds `endpoint_id` to filter stacks in `get_stack_id_from_name` and `resolve_stack` in `helpers.rs`, which fixes the incorrect resolution. This function is only used by `stacks` subcommands (`deploy`, `remove`, `start`, `stop`, `resource-control`), most of which require `--endpoint` to be specified, so passing `endpoint_id` through is a non-breaking change.

This PR also adds `get_stack_id_from_name_filters_by_endpoint_id` unit test, which mocks an API response containing two stacks with identical names on different endpoints, asserting each resolves to its correct ID and that a non-existent endpoint returns `None`. This test fails against the previous implementation.